### PR TITLE
build: Switch to Scala 2.12 because the ecosystem is not ready yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: scala
 jdk: openjdk8
 scala:
-  - 2.13.1
+  - 2.12.10
 
 before_install:
   - git fetch --tags

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ ThisBuild / scmInfo := Some(
   ScmInfo(url("https://github.com/avast/scala-server-toolkit"), "scm:git:git@github.com:avast/scala-server-toolkit.git")
 )
 
-ThisBuild / scalaVersion := "2.13.0"
+ThisBuild / scalaVersion := "2.12.10"
 ThisBuild / scalacOptions := ScalacOptions.default
 
 ThisBuild / turbo := true


### PR DESCRIPTION
There is no stable version of http4s for 2.13.