### PR TITLE
build: Downgrade doobie to 0.7.x because of compatibility with http4s…

### DIFF
--- a/doobie-hikari/src/main/scala/com/avast/sst/doobie/DoobieHikariModule.scala
+++ b/doobie-hikari/src/main/scala/com/avast/sst/doobie/DoobieHikariModule.scala
@@ -26,7 +26,7 @@ object DoobieHikariModule {
   )(implicit cs: ContextShift[F]): Resource[F, HikariTransactor[F]] = {
     for {
       hikariConfig <- Resource.liftF(makeHikariConfig(config, metricsTrackerFactory))
-      transactor <- HikariTransactor.fromHikariConfig(hikariConfig, boundedConnectExecutionContext, blocker)
+      transactor <- HikariTransactor.fromHikariConfig(hikariConfig, boundedConnectExecutionContext, blocker.blockingContext)
     } yield transactor
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
 
   object Versions {
 
-    val doobie = "0.8.4"
+    val doobie = "0.7.1"
     val http4s = "0.20.11"
     val micrometer = "1.3.0"
     val silencer = "1.4.4"


### PR DESCRIPTION
… 0.20.x

This is really necessary because doobie 0.8.x depends on newer fs2 which is not compatible with http4s 0.20.x and can lead to runtime errors (experienced).  Thankfully there is not much in 0.8.x of doobie, it's mostly upgrade to cats 2.x which is binary compatible with cats 1.x so this should be safe and we can wait for newer http4s.