### PR TITLE
[WIP] Improve my Scalafix: RFC

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -8,6 +8,7 @@ rules = [
   ExplicitResultTypes
   SortImports
   Disable
+  MissingFinal
 ]
 
 ExplicitResultTypes {
@@ -20,9 +21,71 @@ SortImports.blocks = [
   "scala."
 ]
 
+Disable.symbols = [
+  {
+    regex = "^\\Qscala/collection/mutable\\E.*$"
+    message = "Java collections have better performance, which is what I assume you were trying to do"
+  }
+  {
+    regex = "^\\Qscala/collection/parallel\\E.*$"
+    message = "parallel collections are low performance and block the thread, prefer scalaz.ApplyN"
+  }
+  {
+    regex = "^\\Qscala/math/Big\\E.*$"
+    message = "scala arbitrary precision numbers are broken: https://github.com/scala/bug/issues/9670"
+  }
+  {
+    regex = {
+      includes = [
+        "^\\Qjava/io\\E.*$"
+        "^\\Qscala/io/Source\\E.*$"
+      ]
+    }
+    message = "legacy blocking API, prefer java.nio"
+  }
+  {
+    regex = "^\\Qjava/net/URL#\\E.*$"
+    message = "URL talks to the network for equality, prefer URI"
+  }
+  {
+    regex = {
+      includes = [
+        # overrides not fully implemented: https://github.com/scalacenter/scalafix/pull/634
+        "^.*\\Q#equals().\\E$"
+        "^.*\\Q#hashCode().\\E$"
+        "^.*\\Q#toString().\\E$" # doesn't catch string interpolators...
+        # more to add here...
+      ]
+    }
+    message = "prefer scalaz.{Equal, Show, Liskov, etc}"
+  }
+
+  {
+    symbol = "scala/Enumeration"
+    message = "prefer a sealed abstract class"
+  }
+
+  {
+    regex = {
+      includes = [
+        "^\\Qscala/util/Either.LeftProjection#get().\\E$"
+        "^\\Qscala/util/Either.RightProjection#get().\\E$"
+        "^\\Qscala/util/Try#get().\\E$"
+        "^\\Qscala/Option#get().\\E$"
+        "^\\Qscala/collection/IterableLike#head().\\E$"
+      ]
+    }
+    message = "not a total function"
+  }
+]
+
 Disable.ifSynthetic = [
   "java/io/Serializable"
   "scala/Any"
+  "scala/Product"
+
+  # local type inference + covariant types fires this
+  # "scala/Nothing"
 
   # when upstream broke noImplicitConversion and we don't agree that their
   # implicits are worth the mental burden.
@@ -41,3 +104,127 @@ Disable.ifSynthetic = [
     message = "not a total function"
   }
 ]
+
+//Disable.unlessInside = [
+//  {
+//    safeBlocks = [
+//      "fommil/std/IO"
+//      "scalaz/ioeffect/IO"
+//      "scalaz/ioeffect/Task"
+//      "scalaz/ApplicativeError.handleError"
+//      "scalaz/ApplicativeError.raiseError"
+//      "scalaz/syntax/ApplicativeErrorOps.handleError"
+//      "scalaz/syntax/ApplicativeErrorOps.recover"
+//      "scalaz/syntax/MonadErrorOps.emap"
+//      "scalaz/zio/IO"
+//      "scalaz/zio/Task"
+//      "scalaz/zio/UIO"
+//      "scalaz/zio/ZIO"
+//      "scalaz/zio/ZIO_E_Throwable.effect"
+//      "scalaz/zio/ZIOFunctions.effectAsync"
+//      "scalaz/zio/ZIOFunctions.effectTotal"
+//      "scalaz/zio/ZIOFunctions.effectTotalWith"
+//      "scalaz/zio/ZIOFunctions.fail"
+//      "scalaz/zio/ZIOFunctions.halt"
+//    ]
+//    symbols = [
+//      {
+//        # This takes the approach of banning everything and then blessing things
+//        # we trust. It would be entirely feasible to do it the other way and
+//        # list the explicit list of things that we need to go through IO, but it
+//        # is less safe. We can have another rule if something in an "excludes"
+//        # glob catches unsafe things.
+//        #
+//        # If something is referentially transparent but not total, instead of
+//        # adding to this excludes list, add it to the includes list of the
+//        # scalaz.Maybe.attempt safeBlock. If it can return `null`, add it to a
+//        # scalaz.Maybe.fromNullable safeBlock.
+//        regex = {
+//          includes = [
+//            "^\\Qjava/\\E.*$"
+//            #"^.*$"
+//          ]
+//          excludes = [
+//            "^fommil.*$"
+//            "^scalaz.*$"
+//            "^\\Qjava/lang/String#\\E.*$"
+//            "^\\Qjava/time/Instant#\\E.*$"
+//            "^\\Qjava/time/ZonedDateTime#\\E.*$"
+//            "^\\Qjava/time/temporal/ChronoUnit#\\E.*$"
+//            "^\\Qjava/net/URI#\\E.*$"
+//            "^\\Qjava/net/URLEncoder#\\E.*$"
+//            "^\\Qjava/net/URLDecoder#\\E.*$"
+//            # primitives are not supported: https://github.com/scalameta/scalameta/issues/1488
+//
+//            # WORKAROUND https://github.com/scalacenter/scalafix/issues/715
+//            "^\\Qjava/\\E$"
+//            "^\\Qjava/lang/\\E$"
+//            "^\\Qjava/time/\\E$"
+//            "^\\Qjava/net\\E$"
+//          ]
+//        }
+//        message = "Untrusted third party library must be called from IO, or blessed in scalafix.conf"
+//      }
+//    ]
+//  }
+//  {
+//    safeBlocks = [
+//      "scalaz/`\/`.fromTryCatchNonFatal",
+//      "scalaz/`\/`.fromTryCatchThrowable",
+//      "scalaz/Maybe.attempt",
+//      "scalaz/Maybe.fromTryCatchNonFatal",
+//      "scalaz/Maybe.fromTryCatchThrowable"
+//    ]
+//    symbols = [
+//      {
+//        regex = {
+//          includes = [
+//            # should live in a common file so we don't need to duplicate
+//            "^\\Qjava/net/URLEncoder#\\E.*$"
+//            "^\\Qjava/net/URLDecoder#\\E.*$"
+//          ]
+//          excludes = [
+//          ]
+//        }
+//        message = "Deterministic method is not total, must be called via Maybe.attempt, \/.fromTryCatchNonFatal, etc."
+//      }
+//    ]
+//  }
+//]
+
+DisableSyntax {
+  noAsInstanceOf = true
+  noContravariantTypes = true
+  noCovariantTypes = true
+//  noDefaultArgs = true
+  noFinalVal = true
+  noFinalize = true
+  noImplicitConversion = true
+  noImplicitObject = true
+  noIsInstanceOf = true
+  noNulls = true
+  noReturns = true
+  noSemicolons = true
+  noTabs = true
+  noThrows = true
+  noUniversalEquality = true
+//  noValInAbstract = true
+  noValPatterns = true
+  noVars = true
+  noWhileLoops = true
+  noXml = true
+}
+
+ExplicitResultTypes {
+  unsafeShortenNames = true
+
+  fatalWarnings = true
+
+  # these apply to non-implicits
+  memberKind = [Def, Val]
+  memberVisibility = [Public, Protected]
+
+  # turn to the max...
+  skipSimpleDefinitions = false
+  skipLocalImplicits = false
+}

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -11,10 +11,6 @@ rules = [
   MissingFinal
 ]
 
-ExplicitResultTypes {
-  unsafeShortenNames = true
-}
-
 SortImports.blocks = [
   "java."
   "*"
@@ -194,8 +190,8 @@ Disable.ifSynthetic = [
 
 DisableSyntax {
   noAsInstanceOf = true
-  noContravariantTypes = true
-  noCovariantTypes = true
+//  noContravariantTypes = true
+//  noCovariantTypes = true
 //  noDefaultArgs = true
   noFinalVal = true
   noFinalize = true

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -24,7 +24,7 @@ Disable.symbols = [
   }
   {
     regex = "^\\Qscala/collection/parallel\\E.*$"
-    message = "parallel collections are low performance and block the thread, prefer scalaz.ApplyN"
+    message = "parallel collections are low performance and block the thread, prefer cats.parMapN"
   }
   {
     regex = "^\\Qscala/math/Big\\E.*$"
@@ -53,7 +53,7 @@ Disable.symbols = [
         # more to add here...
       ]
     }
-    message = "prefer scalaz.{Equal, Show, Liskov, etc}"
+    message = "prefer cats.{kernel.Eq, kernel.Hash, Show, etc}"
   }
 
   {
@@ -104,24 +104,22 @@ Disable.ifSynthetic = [
 //Disable.unlessInside = [
 //  {
 //    safeBlocks = [
-//      "fommil/std/IO"
-//      "scalaz/ioeffect/IO"
-//      "scalaz/ioeffect/Task"
-//      "scalaz/ApplicativeError.handleError"
-//      "scalaz/ApplicativeError.raiseError"
-//      "scalaz/syntax/ApplicativeErrorOps.handleError"
-//      "scalaz/syntax/ApplicativeErrorOps.recover"
-//      "scalaz/syntax/MonadErrorOps.emap"
-//      "scalaz/zio/IO"
-//      "scalaz/zio/Task"
-//      "scalaz/zio/UIO"
-//      "scalaz/zio/ZIO"
-//      "scalaz/zio/ZIO_E_Throwable.effect"
-//      "scalaz/zio/ZIOFunctions.effectAsync"
-//      "scalaz/zio/ZIOFunctions.effectTotal"
-//      "scalaz/zio/ZIOFunctions.effectTotalWith"
-//      "scalaz/zio/ZIOFunctions.fail"
-//      "scalaz/zio/ZIOFunctions.halt"
+//      "cats/effect/IO"
+//      "monix/eval/Task"
+//      "cats/ApplicativeError.handleError"
+//      "cats/ApplicativeError.raiseError"
+//      "cats/syntax/ApplicativeErrorOps.handleError"
+//      "cats/syntax/ApplicativeErrorOps.recover"
+//      "zio/IO"
+//      "zio/Task"
+//      "zio/UIO"
+//      "zio/ZIO"
+//      "zio/ZIO_E_Throwable.effect"
+//      "zio/ZIOFunctions.effectAsync"
+//      "zio/ZIOFunctions.effectTotal"
+//      "zio/ZIOFunctions.effectTotalWith"
+//      "zio/ZIOFunctions.fail"
+//      "zio/ZIOFunctions.halt"
 //    ]
 //    symbols = [
 //      {
@@ -133,16 +131,16 @@ Disable.ifSynthetic = [
 //        #
 //        # If something is referentially transparent but not total, instead of
 //        # adding to this excludes list, add it to the includes list of the
-//        # scalaz.Maybe.attempt safeBlock. If it can return `null`, add it to a
-//        # scalaz.Maybe.fromNullable safeBlock.
+//        # cats.syntax.EitherObjectOps.catchNonFatal safeBlock.
 //        regex = {
 //          includes = [
 //            "^\\Qjava/\\E.*$"
 //            #"^.*$"
 //          ]
 //          excludes = [
-//            "^fommil.*$"
-//            "^scalaz.*$"
+//            "^cats.*$"
+//            "^monix.*$"
+//            "^zio.*$"
 //            "^\\Qjava/lang/String#\\E.*$"
 //            "^\\Qjava/time/Instant#\\E.*$"
 //            "^\\Qjava/time/ZonedDateTime#\\E.*$"
@@ -165,11 +163,9 @@ Disable.ifSynthetic = [
 //  }
 //  {
 //    safeBlocks = [
-//      "scalaz/`\/`.fromTryCatchNonFatal",
-//      "scalaz/`\/`.fromTryCatchThrowable",
-//      "scalaz/Maybe.attempt",
-//      "scalaz/Maybe.fromTryCatchNonFatal",
-//      "scalaz/Maybe.fromTryCatchThrowable"
+//      "cats/syntax/EitherObjectOps.catchNonFatal",
+//      "cats/data/Validated.catchNonFatal",
+//      "cats/ApplicativeError.catchNonFatal"
 //    ]
 //    symbols = [
 //      {

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -101,7 +101,7 @@ Disable.ifSynthetic = [
   }
 ]
 
-//Disable.unlessInside = [
+Disable.unlessInside = [
 //  {
 //    safeBlocks = [
 //      "cats/effect/IO"
@@ -161,28 +161,28 @@ Disable.ifSynthetic = [
 //      }
 //    ]
 //  }
-//  {
-//    safeBlocks = [
-//      "cats/syntax/EitherObjectOps.catchNonFatal",
-//      "cats/data/Validated.catchNonFatal",
-//      "cats/ApplicativeError.catchNonFatal"
-//    ]
-//    symbols = [
-//      {
-//        regex = {
-//          includes = [
-//            # should live in a common file so we don't need to duplicate
-//            "^\\Qjava/net/URLEncoder#\\E.*$"
-//            "^\\Qjava/net/URLDecoder#\\E.*$"
-//          ]
-//          excludes = [
-//          ]
-//        }
-//        message = "Deterministic method is not total, must be called via Maybe.attempt, \/.fromTryCatchNonFatal, etc."
-//      }
-//    ]
-//  }
-//]
+  {
+    safeBlocks = [
+      "cats/syntax/EitherObjectOps.catchNonFatal",
+      "cats/data/Validated.catchNonFatal",
+      "cats/ApplicativeError.catchNonFatal"
+    ]
+    symbols = [
+      {
+        regex = {
+          includes = [
+            # should live in a common file so we don't need to duplicate
+            "^\\Qjava/net/URLEncoder#\\E.*$"
+            "^\\Qjava/net/URLDecoder#\\E.*$"
+          ]
+          excludes = [
+          ]
+        }
+        message = "Deterministic method is not total, must be called via Either.catchNonFatal, etc."
+      }
+    ]
+  }
+]
 
 DisableSyntax {
   noAsInstanceOf = true

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -6,12 +6,19 @@ rules = [
   ProcedureSyntax
   DisableSyntax
   ExplicitResultTypes
+  SortImports
   Disable
 ]
 
 ExplicitResultTypes {
   unsafeShortenNames = true
 }
+
+SortImports.blocks = [
+  "java."
+  "*"
+  "scala."
+]
 
 Disable.ifSynthetic = [
   "java/io/Serializable"

--- a/cassandra-datastax-driver-pureconfig/src/main/scala/com/avast/sst/datastax/pureconfig/ConfigReaders.scala
+++ b/cassandra-datastax-driver-pureconfig/src/main/scala/com/avast/sst/datastax/pureconfig/ConfigReaders.scala
@@ -1,9 +1,9 @@
 package com.avast.sst.datastax.pureconfig
 
 import com.avast.sst.datastax.config._
-import pureconfig.generic.ProductHint
-import pureconfig.generic.semiauto.{deriveEnumerationReader, deriveReader}
-import pureconfig.{ConfigFieldMapping, ConfigReader, PascalCase}
+import pureconfig.generic.ProductHint
+import pureconfig.generic.semiauto.{deriveEnumerationReader, deriveReader}
+import pureconfig.{ConfigFieldMapping, ConfigReader, PascalCase}
 
 trait ConfigReaders {
 

--- a/cassandra-datastax-driver-pureconfig/src/main/scala/com/avast/sst/datastax/pureconfig/ConfigReaders.scala
+++ b/cassandra-datastax-driver-pureconfig/src/main/scala/com/avast/sst/datastax/pureconfig/ConfigReaders.scala
@@ -1,9 +1,9 @@
 package com.avast.sst.datastax.pureconfig
 
 import com.avast.sst.datastax.config._
-import pureconfig.generic.ProductHint
-import pureconfig.generic.semiauto.{deriveEnumerationReader, deriveReader}
-import pureconfig.{ConfigFieldMapping, ConfigReader, PascalCase}
+import pureconfig.generic.ProductHint
+import pureconfig.generic.semiauto.{deriveEnumerationReader, deriveReader}
+import pureconfig.{ConfigFieldMapping, ConfigReader, PascalCase}
 
 trait ConfigReaders {
 

--- a/cassandra-datastax-driver-pureconfig/src/main/scala/com/avast/sst/datastax/pureconfig/implicits.scala
+++ b/cassandra-datastax-driver-pureconfig/src/main/scala/com/avast/sst/datastax/pureconfig/implicits.scala
@@ -1,7 +1,7 @@
 package com.avast.sst.datastax.pureconfig
 
 import pureconfig.ConfigFieldMapping
-import pureconfig.generic.ProductHint
+import pureconfig.generic.ProductHint
 
 /** Contains [[pureconfig.ConfigReader]] instances with default "kebab-case" naming convention. */
 object implicits extends ConfigReaders {

--- a/cassandra-datastax-driver-pureconfig/src/main/scala/com/avast/sst/datastax/pureconfig/implicits.scala
+++ b/cassandra-datastax-driver-pureconfig/src/main/scala/com/avast/sst/datastax/pureconfig/implicits.scala
@@ -1,7 +1,7 @@
 package com.avast.sst.datastax.pureconfig
 
 import pureconfig.ConfigFieldMapping
-import pureconfig.generic.ProductHint
+import pureconfig.generic.ProductHint
 
 /** Contains [[pureconfig.ConfigReader]] instances with default "kebab-case" naming convention. */
 object implicits extends ConfigReaders {

--- a/cassandra-datastax-driver/src/main/scala/com/avast/sst/datastax/CassandraDatastaxDriverModule.scala
+++ b/cassandra-datastax-driver/src/main/scala/com/avast/sst/datastax/CassandraDatastaxDriverModule.scala
@@ -1,12 +1,12 @@
 package com.avast.sst.datastax
 
 import cats.effect.{Resource, Sync}
-import com.avast.sst.datastax.DatastaxHelper._
-import com.avast.sst.datastax.config.CassandraDatastaxDriverConfig
-import com.datastax.oss.driver.api.core.CqlSession
-import com.datastax.oss.driver.api.core.config.DefaultDriverOption._
-import com.datastax.oss.driver.api.core.config.{DriverConfigLoader, ProgrammaticDriverConfigLoaderBuilder => DriverBuilder}
-import javax.net.ssl.SSLContext
+import com.avast.sst.datastax.DatastaxHelper._
+import com.avast.sst.datastax.config.CassandraDatastaxDriverConfig
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption._
+import com.datastax.oss.driver.api.core.config.{DriverConfigLoader, ProgrammaticDriverConfigLoaderBuilder => DriverBuilder}
+import javax.net.ssl.SSLContext
 
 object CassandraDatastaxDriverModule {
 

--- a/cassandra-datastax-driver/src/main/scala/com/avast/sst/datastax/CassandraDatastaxDriverModule.scala
+++ b/cassandra-datastax-driver/src/main/scala/com/avast/sst/datastax/CassandraDatastaxDriverModule.scala
@@ -1,12 +1,12 @@
 package com.avast.sst.datastax
 
 import cats.effect.{Resource, Sync}
-import com.avast.sst.datastax.config.CassandraDatastaxDriverConfig
-import com.avast.sst.datastax.DatastaxHelper._
-import com.datastax.oss.driver.api.core.CqlSession
-import com.datastax.oss.driver.api.core.config.DefaultDriverOption._
-import com.datastax.oss.driver.api.core.config.{DriverConfigLoader, ProgrammaticDriverConfigLoaderBuilder => DriverBuilder}
-import javax.net.ssl.SSLContext
+import com.avast.sst.datastax.DatastaxHelper._
+import com.avast.sst.datastax.config.CassandraDatastaxDriverConfig
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption._
+import com.datastax.oss.driver.api.core.config.{DriverConfigLoader, ProgrammaticDriverConfigLoaderBuilder => DriverBuilder}
+import javax.net.ssl.SSLContext
 
 object CassandraDatastaxDriverModule {
 

--- a/cassandra-datastax-driver/src/main/scala/com/avast/sst/datastax/DatastaxHelper.scala
+++ b/cassandra-datastax-driver/src/main/scala/com/avast/sst/datastax/DatastaxHelper.scala
@@ -2,8 +2,8 @@ package com.avast.sst.datastax
 
 import com.datastax.oss.driver.api.core.config.{DriverOption, ProgrammaticDriverConfigLoaderBuilder => DriverBuilder}
 
-import scala.collection.JavaConverters._
-import scala.concurrent.duration.Duration
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.Duration
 
 /** Helper functions to construct Datastax session using Java builder. */
 private[datastax] object DatastaxHelper {

--- a/cassandra-datastax-driver/src/main/scala/com/avast/sst/datastax/DatastaxHelper.scala
+++ b/cassandra-datastax-driver/src/main/scala/com/avast/sst/datastax/DatastaxHelper.scala
@@ -2,8 +2,8 @@ package com.avast.sst.datastax
 
 import com.datastax.oss.driver.api.core.config.{DriverOption, ProgrammaticDriverConfigLoaderBuilder => DriverBuilder}
 
-import scala.collection.JavaConverters._
-import scala.concurrent.duration.Duration
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.Duration
 
 /** Helper functions to construct Datastax session using Java builder. */
 private[datastax] object DatastaxHelper {

--- a/example/src/main/scala/com/avast/sst/example/module/Http4sRoutingModule.scala
+++ b/example/src/main/scala/com/avast/sst/example/module/Http4sRoutingModule.scala
@@ -18,6 +18,7 @@ class Http4sRoutingModule(randomService: RandomService,
 
   private val helloWorldRoute = routeMetrics.wrap("hello")(Ok("Hello World!"))
 
+  @SuppressWarnings(Array("scalafix:Disable.toString"))
   private val routes = HttpRoutes.of[Task] {
     case GET -> Root / "hello"           => helloWorldRoute
     case GET -> Root / "random"          => randomService.randomNumber.map(_.toString).flatMap(Ok(_))

--- a/http4s-client-blaze/src/test/scala/com/avast/sst/http4s/client/Http4SBlazeClientTest.scala
+++ b/http4s-client-blaze/src/test/scala/com/avast/sst/http4s/client/Http4SBlazeClientTest.scala
@@ -2,9 +2,9 @@ package com.avast.sst.http4s.client
 
 import cats.effect._
 import org.http4s.headers.{`User-Agent`, AgentComment, AgentProduct}
+import org.scalatest.funsuite.AsyncFunSuite
 
 import scala.concurrent.ExecutionContext
-import org.scalatest.funsuite.AsyncFunSuite
 
 class Http4SBlazeClientTest extends AsyncFunSuite {
 

--- a/http4s-server/src/main/scala/com/avast/sst/http4s/server/middleware/CorrelationIdMiddleware.scala
+++ b/http4s-server/src/main/scala/com/avast/sst/http4s/server/middleware/CorrelationIdMiddleware.scala
@@ -58,6 +58,7 @@ object CorrelationIdMiddleware {
 
   final case class CorrelationId(value: String) extends AnyVal
 
+  @SuppressWarnings(Array("scalafix:Disable.toString"))
   def default[F[_]: Sync]: F[CorrelationIdMiddleware[F]] = {
     Key.newKey[F, CorrelationId].map { attributeKey =>
       new CorrelationIdMiddleware(CaseInsensitiveString("Correlation-ID"), attributeKey, () => UUID.randomUUID().toString)

--- a/http4s-server/src/test/scala/com/avast/sst/http4s/server/middleware/CorrelationIdMiddlewareTest.scala
+++ b/http4s-server/src/test/scala/com/avast/sst/http4s/server/middleware/CorrelationIdMiddlewareTest.scala
@@ -9,10 +9,11 @@ import org.http4s.dsl.Http4sDsl
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.util.CaseInsensitiveString
 import org.http4s.{Header, HttpRoutes, Request, Uri}
-
-import scala.concurrent.ExecutionContext
 import org.scalatest.funsuite.AsyncFunSuite
 
+import scala.concurrent.ExecutionContext
+
+@SuppressWarnings(Array("scalafix:Disable.toString", "scalafix:Disable.get"))
 class CorrelationIdMiddlewareTest extends AsyncFunSuite with Http4sDsl[IO] {
 
   implicit private val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)

--- a/jvm/src/main/scala/com/avast/sst/jvm/execution/ConfigurableThreadFactory.scala
+++ b/jvm/src/main/scala/com/avast/sst/jvm/execution/ConfigurableThreadFactory.scala
@@ -10,7 +10,9 @@ import com.avast.sst.jvm.execution.ConfigurableThreadFactory.Config
 /** Thread factory (both [[java.util.concurrent.ThreadFactory]] and [[java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory]])
   * that creates new threads according to the provided [[com.avast.sst.jvm.execution.ConfigurableThreadFactory.Config]].
   */
-class ConfigurableThreadFactory(config: Config) extends ThreadFactory with ForkJoinWorkerThreadFactory {
+class ConfigurableThreadFactory(config: Config, uncaughtExceptionHandler: UncaughtExceptionHandler = LoggingUncaughtExceptionHandler)
+    extends ThreadFactory
+    with ForkJoinWorkerThreadFactory {
 
   private val counter = new AtomicLong(0L)
 
@@ -24,7 +26,7 @@ class ConfigurableThreadFactory(config: Config) extends ThreadFactory with ForkJ
     config.nameFormat.map(_.format(counter.getAndIncrement())).foreach(thread.setName)
     thread.setDaemon(config.daemon)
     thread.setPriority(config.priority)
-    thread.setUncaughtExceptionHandler(config.uncaughtExceptionHandler)
+    thread.setUncaughtExceptionHandler(uncaughtExceptionHandler)
     thread
   }
 
@@ -35,9 +37,6 @@ object ConfigurableThreadFactory {
   /**
     * @param nameFormat Formatted with long number, e.g. my-thread-%02d
     */
-  final case class Config(nameFormat: Option[String] = None,
-                          daemon: Boolean = false,
-                          priority: Int = Thread.NORM_PRIORITY,
-                          uncaughtExceptionHandler: UncaughtExceptionHandler = LoggingUncaughtExceptionHandler)
+  final case class Config(nameFormat: Option[String] = None, daemon: Boolean = false, priority: Int = Thread.NORM_PRIORITY)
 
 }

--- a/jvm/src/main/scala/com/avast/sst/jvm/system/console/Console.scala
+++ b/jvm/src/main/scala/com/avast/sst/jvm/system/console/Console.scala
@@ -21,6 +21,7 @@ trait Console[F[_]] {
 
 object Console {
 
+  @SuppressWarnings(Array("scalafix:Disable.Reader", "scalafix:Disable.OutputStream", "scalafix:Disable.println"))
   def apply[F[_]: Sync](in: Reader, out: OutputStream, err: OutputStream): Console[F] = new Console[F] {
 
     private val F = Sync[F]

--- a/jvm/src/test/scala/com/avast/sst/jvm/system/console/ConsoleModuleTest.scala
+++ b/jvm/src/test/scala/com/avast/sst/jvm/system/console/ConsoleModuleTest.scala
@@ -3,10 +3,16 @@ package com.avast.sst.jvm.system.console
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import cats.effect.SyncIO
-
-import scala.{Console => SConsole}
 import org.scalatest.funsuite.AnyFunSuite
 
+import scala.{Console => SConsole}
+
+@SuppressWarnings(
+  Array("scalafix:Disable.toString",
+        "scalafix:Disable.ByteArrayInputStream",
+        "scalafix:Disable.ByteArrayOutputStream",
+        "scalafix:DisableSyntax.==")
+)
 class ConsoleModuleTest extends AnyFunSuite {
 
   test("Console input") {

--- a/micrometer-jmx/src/main/scala/com/avast/sst/micrometer/jmx/MicrometerJmxModule.scala
+++ b/micrometer-jmx/src/main/scala/com/avast/sst/micrometer/jmx/MicrometerJmxModule.scala
@@ -54,7 +54,7 @@ object MicrometerJmxModule {
     override val step: Duration = Duration.ofMillis(c.step.toMillis)
 
     // the method is @Nullable and we don't need to implement it here
-    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @SuppressWarnings(Array("org.wartremover.warts.Null", "scalafix:DisableSyntax.null"))
     override def get(key: String): String = null
 
   }

--- a/micrometer-jmx/src/main/scala/com/avast/sst/micrometer/jmx/TypeScopeNameObjectNameFactory.scala
+++ b/micrometer-jmx/src/main/scala/com/avast/sst/micrometer/jmx/TypeScopeNameObjectNameFactory.scala
@@ -5,7 +5,7 @@ import java.util.regex.Pattern
 
 import cats.syntax.either._
 import com.codahale.metrics.jmx.{DefaultObjectNameFactory, ObjectNameFactory}
-import javax.management.ObjectName;
+import javax.management.ObjectName
 
 /** This is custom [[com.codahale.metrics.jmx.ObjectNameFactory]] which uses "type-scope-name" hierarchy of resulting
   * [[javax.management.ObjectName]] (levels 3-N are glued together).

--- a/micrometer-statsd/src/main/scala/com/avast/sst/micrometer/statsd/MicrometerStatsDModule.scala
+++ b/micrometer-statsd/src/main/scala/com/avast/sst/micrometer/statsd/MicrometerStatsDModule.scala
@@ -50,7 +50,7 @@ object MicrometerStatsDModule {
     override val buffered: Boolean = c.buffered
 
     // the method is @Nullable and we don't need to implement it here
-    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @SuppressWarnings(Array("org.wartremover.warts.Null", "scalafix:DisableSyntax.null"))
     override def get(key: String): String = null
 
   }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -24,7 +24,8 @@ object BuildSettings {
       Wart.DefaultArguments // for constructors for PureConfig
     ),
     ThisBuild / scalafixDependencies ++= Seq(
-      Dependencies.scalazzi // https://github.com/scalaz/scalazzi
+      Dependencies.scalazzi, // https://github.com/scalaz/scalazzi
+      Dependencies.sortImports // https://github.com/NeQuissimus/sort-imports
     ),
     scalacOptions ++= Seq(
       "-Yrangepos", // for scalafix. required by SemanticDB compiler plugin

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies {
   val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.12.2"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.1.0"
   val scalazzi = "com.github.vovapolu" %% "scaluzzi" % "0.1.3"
+  val sortImports = "com.nequissimus" %% "sort-imports" % "0.3.2"
   val silencer = "com.github.ghik" % "silencer-plugin" % Versions.silencer cross CrossVersion.full
   val silencerLib = "com.github.ghik" % "silencer-lib" % Versions.silencer cross CrossVersion.full
   val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.30"

--- a/pureconfig/src/test/scala/com/avast/sst/pureconfig/PureConfigModuleTest.scala
+++ b/pureconfig/src/test/scala/com/avast/sst/pureconfig/PureConfigModuleTest.scala
@@ -2,10 +2,10 @@ package com.avast.sst.pureconfig
 
 import cats.data.NonEmptyList
 import cats.effect.SyncIO
+import org.scalatest.funsuite.AnyFunSuite
 import pureconfig.error.ConfigReaderException
 import pureconfig.generic.semiauto.deriveReader
 import pureconfig.{ConfigReader, ConfigSource}
-import org.scalatest.funsuite.AnyFunSuite
 
 class PureConfigModuleTest extends AnyFunSuite {
 


### PR DESCRIPTION
This adds many of the Scalazzi rules. (also sorts imports, but that's a small thing.)
What rules do we want to have. Which ones would we like to keep? Which ones would we like to add?
We would need to translate some rules from `scalaz` to `cats`.
Eventually we could migrate away from Wartremover.

Comments and suggestions welcome.

For example, we probably don't want to enforce `noDefaultArgs`, because default args is essential feature of config classes with PureConfig.
On the other hand, we might want to enforce `noValInAbstract`, because it could lead to initialization-related runtime bugs.

EDIT: some of the changes are only of whitespace, so I recommend to turn on _Hide whitespace changes_