### PR TITLE
lint: Introduce scalafix DisableSyntax rules

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -42,10 +42,6 @@ Disable.ifSynthetic = [
 
 DisableSyntax {
   noAsInstanceOf = true
-//  noContravariantTypes = true
-//  noCovariantTypes = true
-//  noDefaultArgs = true
-//  noFinalVal = true // https://github.com/sbt/sbt/issues/1543
   noFinalize = true
   noImplicitConversion = true
   noImplicitObject = true // https://stackoverflow.com/questions/20380800/scala-implicits-resolution-mechanism-is-declaration-order-dependent#comment31809401_20381535
@@ -56,7 +52,6 @@ DisableSyntax {
   noTabs = true
   noThrows = true
   noUniversalEquality = true
-//  noValInAbstract = true  used widely in this library, but should be on in applications
   noValPatterns = true
   noVars = true
   noWhileLoops = true

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -45,7 +45,7 @@ DisableSyntax {
 //  noContravariantTypes = true
 //  noCovariantTypes = true
 //  noDefaultArgs = true
-  noFinalVal = true // https://github.com/sbt/sbt/issues/1543
+//  noFinalVal = true // https://github.com/sbt/sbt/issues/1543
   noFinalize = true
   noImplicitConversion = true
   noImplicitObject = true // https://stackoverflow.com/questions/20380800/scala-implicits-resolution-mechanism-is-declaration-order-dependent#comment31809401_20381535

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -48,7 +48,7 @@ DisableSyntax {
   noFinalVal = true
   noFinalize = true
   noImplicitConversion = true
-  noImplicitObject = true
+  noImplicitObject = true // https://stackoverflow.com/questions/20380800/scala-implicits-resolution-mechanism-is-declaration-order-dependent#comment31809401_20381535
   noIsInstanceOf = true
   noNulls = true
   noReturns = true

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -40,6 +40,29 @@ Disable.ifSynthetic = [
   }
 ]
 
+DisableSyntax {
+  noAsInstanceOf = true
+//  noContravariantTypes = true
+//  noCovariantTypes = true
+//  noDefaultArgs = true
+  noFinalVal = true
+  noFinalize = true
+  noImplicitConversion = true
+  noImplicitObject = true
+  noIsInstanceOf = true
+  noNulls = true
+  noReturns = true
+  noSemicolons = true
+  noTabs = true
+  noThrows = true
+  noUniversalEquality = true
+//  noValInAbstract = true  used widely in this library, but should be on in applications
+  noValPatterns = true
+  noVars = true
+  noWhileLoops = true
+  noXml = true
+}
+
 ExplicitResultTypes {
   fatalWarnings = true
 

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -45,7 +45,7 @@ DisableSyntax {
 //  noContravariantTypes = true
 //  noCovariantTypes = true
 //  noDefaultArgs = true
-  noFinalVal = true
+  noFinalVal = true // https://github.com/sbt/sbt/issues/1543
   noFinalize = true
   noImplicitConversion = true
   noImplicitObject = true // https://stackoverflow.com/questions/20380800/scala-implicits-resolution-mechanism-is-declaration-order-dependent#comment31809401_20381535

--- a/jvm/src/test/scala/com/avast/sst/jvm/system/console/ConsoleModuleTest.scala
+++ b/jvm/src/test/scala/com/avast/sst/jvm/system/console/ConsoleModuleTest.scala
@@ -13,7 +13,7 @@ class ConsoleModuleTest extends AnyFunSuite {
     SConsole.withIn(new ByteArrayInputStream("test input\n".getBytes("UTF-8"))) {
       val test = for {
         line <- ConsoleModule.make[SyncIO].readLine
-      } yield assert(line == "test input")
+      } yield assert(line === "test input")
 
       test.unsafeRunSync()
     }

--- a/micrometer-jmx/src/main/scala/com/avast/sst/micrometer/jmx/MicrometerJmxModule.scala
+++ b/micrometer-jmx/src/main/scala/com/avast/sst/micrometer/jmx/MicrometerJmxModule.scala
@@ -54,7 +54,7 @@ object MicrometerJmxModule {
     override val step: Duration = Duration.ofMillis(c.step.toMillis)
 
     // the method is @Nullable and we don't need to implement it here
-    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @SuppressWarnings(Array("org.wartremover.warts.Null", "scalafix:DisableSyntax.null"))
     override def get(key: String): String = null
 
   }

--- a/micrometer-jmx/src/main/scala/com/avast/sst/micrometer/jmx/MicrometerJmxModule.scala
+++ b/micrometer-jmx/src/main/scala/com/avast/sst/micrometer/jmx/MicrometerJmxModule.scala
@@ -54,7 +54,7 @@ object MicrometerJmxModule {
     override val step: Duration = Duration.ofMillis(c.step.toMillis)
 
     // the method is @Nullable and we don't need to implement it here
-    @SuppressWarnings(Array("org.wartremover.warts.Null", "scalafix:DisableSyntax.null"))
+    @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
     override def get(key: String): String = null
 
   }

--- a/micrometer-statsd/src/main/scala/com/avast/sst/micrometer/statsd/MicrometerStatsDModule.scala
+++ b/micrometer-statsd/src/main/scala/com/avast/sst/micrometer/statsd/MicrometerStatsDModule.scala
@@ -50,7 +50,7 @@ object MicrometerStatsDModule {
     override val buffered: Boolean = c.buffered
 
     // the method is @Nullable and we don't need to implement it here
-    @SuppressWarnings(Array("org.wartremover.warts.Null", "scalafix:DisableSyntax.null"))
+    @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
     override def get(key: String): String = null
 
   }

--- a/micrometer-statsd/src/main/scala/com/avast/sst/micrometer/statsd/MicrometerStatsDModule.scala
+++ b/micrometer-statsd/src/main/scala/com/avast/sst/micrometer/statsd/MicrometerStatsDModule.scala
@@ -50,7 +50,7 @@ object MicrometerStatsDModule {
     override val buffered: Boolean = c.buffered
 
     // the method is @Nullable and we don't need to implement it here
-    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @SuppressWarnings(Array("org.wartremover.warts.Null", "scalafix:DisableSyntax.null"))
     override def get(key: String): String = null
 
   }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -14,6 +14,7 @@ object BuildSettings {
       Dependencies.silencerLib
     ),
     Compile / compile / wartremoverErrors ++= Warts.all filterNot Set(
+      Wart.Null, // checked by scalafix
       Wart.Nothing, // keep, false positives all around
       Wart.Overloading,
       Wart.Any, // keep, false positives all around


### PR DESCRIPTION
These rules prevent writing problematic Scala code. These's a considerable overlap with WartRemover. Having these rules gives us option to supersede WartRemover with scalafix entirely.

Documentation for the rules is provided at scalafix's website: https://scalacenter.github.io/scalafix/docs/rules/DisableSyntax.html

---

I would like to open discussion about which of the `DisableSyntax` are good for this project. Here's my suggestion, I took inspiration from the [Scalazzi project](https://github.com/scalaz/scalazzi/blob/master/scalafix.conf). Please keep in mind that each rule can be suppressed in-place. I've left some rules commented out for the sake of discussion -- the eventual merge won't contain any commented code :wink: 