### PR TITLE
lint: Introduce scalafix Disable rules for partial (non-total) functions

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -80,6 +80,30 @@ Disable.ifSynthetic = [
   }
 ]
 
+Disable.unlessInside = [
+  {
+    safeBlocks = [
+      "cats/syntax/EitherObjectOps.catchNonFatal",
+      "cats/data/Validated.catchNonFatal",
+      "cats/ApplicativeError.catchNonFatal"
+    ]
+    symbols = [
+      {
+        regex = {
+          includes = [
+            # should live in a common file so we don't need to duplicate
+            "^\\Qjava/net/URLEncoder#\\E.*$"
+            "^\\Qjava/net/URLDecoder#\\E.*$"
+          ]
+          excludes = [
+          ]
+        }
+        message = "Deterministic method is not total, must be called via Either.catchNonFatal, etc."
+      }
+    ]
+  }
+]
+
 DisableSyntax {
   noAsInstanceOf = true
   noFinalize = true

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -83,17 +83,64 @@ Disable.ifSynthetic = [
 Disable.unlessInside = [
   {
     safeBlocks = [
-      "cats/syntax/EitherObjectOps.catchNonFatal",
-      "cats/data/Validated.catchNonFatal",
+      "cats/effect/IO"
+      "cats/effect/Sync.delay"
+      "monix/eval/Task"
+      "cats/ApplicativeError.handleError"
+      "cats/ApplicativeError.raiseError"
+      "cats/syntax/ApplicativeErrorOps.handleError"
+      "cats/syntax/ApplicativeErrorOps.recover"
+      "zio/IO"
+      "zio/Task"
+      "zio/ZIO"
+      "zio/ZIO_E_Throwable.effect"
+      "zio/ZIOFunctions.effectAsync"
+      "zio/ZIOFunctions.effectTotal"
+      "zio/ZIOFunctions.effectTotalWith"
+      "zio/ZIOFunctions.fail"
+      "zio/ZIOFunctions.halt"
+    ]
+    symbols = [
+      {
+        # If something is referentially transparent but not total, instead of
+        # adding to this excludes list, add it to the includes list of the
+        # cats.syntax.EitherObjectOps.catchNonFatal safeBlock.
+        regex = {
+          includes = [
+            "^\\Qjava/net/InetAddress#getByAddress().\\E$"
+            "^\\Qjava/net/InetAddress#getByName(\\E.*$"
+            "^\\Qjava/net/InetSocketAddress#<init>().\\E$"
+            "^\\Qjava/net/InetSocketAddress#<init>(+2).\\E$"
+          ]
+          excludes = [
+          ]
+        }
+        message = "Method is sideeffectful, must be called from Task/IO/ZIO"
+      }
+    ]
+  }
+  {
+    safeBlocks = [
+      "cats/syntax/EitherObjectOps.catchNonFatal"
+      "cats/data/Validated.catchNonFatal"
       "cats/ApplicativeError.catchNonFatal"
+      "cats/effect/IO"
+      "cats/effect/Sync.delay"
+      "monix/eval/Task"
+      "zio/IO"
+      "zio/Task"
+      "zio/ZIO"
+      "zio/ZIO_E_Throwable.effect"
     ]
     symbols = [
       {
         regex = {
           includes = [
-            # should live in a common file so we don't need to duplicate
             "^\\Qjava/net/URLEncoder#\\E.*$"
             "^\\Qjava/net/URLDecoder#\\E.*$"
+            "^\\Qjava/net/InetAddress#getByAddress(+1).\\E$"
+            "^\\Qjava/net/InetSocketAddress#<init>(+1).\\E$"
+            "^\\Qjava/net/InetSocketAddress#createUnresolved().\\E$"
           ]
           excludes = [
           ]

--- a/http4s-server/src/test/scala/com/avast/sst/http4s/server/middleware/CorrelationIdMiddlewareTest.scala
+++ b/http4s-server/src/test/scala/com/avast/sst/http4s/server/middleware/CorrelationIdMiddlewareTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.funsuite.AsyncFunSuite
 
 import scala.concurrent.ExecutionContext
 
-@SuppressWarnings(Array("scalafix:Disable.get", "scalafix:Disable.toString"))
+@SuppressWarnings(Array("scalafix:Disable.get", "scalafix:Disable.toString", "scalafix:Disable.createUnresolved"))
 class CorrelationIdMiddlewareTest extends AsyncFunSuite with Http4sDsl[IO] {
 
   implicit private val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)


### PR DESCRIPTION
I took inspiration from the [Scalazzi project](https://github.com/scalaz/scalazzi/blob/master/scalafix.conf)
