### PR TITLE
fix: Default value for maxOrphanRequests in Cassandra driver

### DIFF
--- a/cassandra-datastax-driver/src/main/scala/com/avast/sst/datastax/config/advanced.scala
+++ b/cassandra-datastax-driver/src/main/scala/com/avast/sst/datastax/config/advanced.scala
@@ -145,7 +145,7 @@ final case class ConnectionConfig(
 
 object ConnectionConfig {
   val Default: ConnectionConfig =
-    ConnectionConfig(InitQueryTimeout, InitQueryTimeout, PoolConfig.Default, PoolConfig.Default, 1024, 24576, true)
+    ConnectionConfig(InitQueryTimeout, InitQueryTimeout, PoolConfig.Default, PoolConfig.Default, 1024, 256, true)
 }
 
 /** The driver maintains a connection pool to each node, according to the distance assigned to it


### PR DESCRIPTION
I'm getting the following error:

```WARN c.d.o.driver.internal.core.channel.ChannelFactory: [s0] Invalid value for advanced.connection.max-orphan-requests: 24576. It must be lower than advanced.connection.max-requests-per-connection. Defaulting to 256 (1/4 of max-requests) instead.```

I presume it was just a typo originally.