### PR TITLE
fix: Do not set all SocketOptions by default

### DIFF
--- a/http4s-server-blaze/src/main/scala/com/avast/sst/http4s/server/Http4sBlazeServerConfig.scala
+++ b/http4s-server-blaze/src/main/scala/com/avast/sst/http4s/server/Http4sBlazeServerConfig.scala
@@ -29,9 +29,9 @@ object Http4sBlazeServerConfig {
 
   final case class SocketOptions(
       tcpNoDelay: Boolean = true,
-      soKeepAlive: Boolean = true,
-      soReuseAddr: Boolean = true,
-      soReusePort: Boolean = true
+      soKeepAlive: Option[Boolean] = None,
+      soReuseAddr: Option[Boolean] = None,
+      soReusePort: Option[Boolean] = None
   )
 
 }


### PR DESCRIPTION
Some of the SocketOptions are not supported on other platforms.
By default those should not be set.

Closes #764