### PR TITLE
Extend PureConfigModule with overrides from environment variables

### DIFF
--- a/pureconfig/src/main/scala/com/avast/sst/pureconfig/PureConfigModule.scala
+++ b/pureconfig/src/main/scala/com/avast/sst/pureconfig/PureConfigModule.scala
@@ -3,33 +3,97 @@ package com.avast.sst.pureconfig
 import cats.data.NonEmptyList
 import cats.effect.Sync
 import cats.syntax.either._
-import pureconfig.error.{ConfigReaderFailure, ConfigReaderFailures, ConvertFailure}
-import pureconfig.{ConfigReader, ConfigSource}
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import com.typesafe.config.{Config, ConfigFactory}
+import pureconfig.error.{
+  ConfigReaderFailure,
+  ConfigReaderFailures,
+  ConvertFailure
+}
+import pureconfig.{
+  CamelCase,
+  ConfigReader,
+  ConfigSource,
+  KebabCase,
+  NamingConvention
+}
 
+import java.util.Properties
 import scala.reflect.ClassTag
 
 /** Provides loading of configuration into case class via PureConfig. */
 object PureConfigModule {
 
   /** Loads the case class `A` using Lightbend Config's standard behavior. */
-  def make[F[_]: Sync, A: ConfigReader]: F[Either[NonEmptyList[String], A]] = make(ConfigSource.default)
+  def make[F[_]: Sync, A: ConfigReader]: F[Either[NonEmptyList[String], A]] =
+    make(ConfigSource.default)
 
   /** Loads the case class `A` using provided [[pureconfig.ConfigSource]]. */
-  def make[F[_]: Sync, A: ConfigReader](source: ConfigSource): F[Either[NonEmptyList[String], A]] = {
+  def make[F[_]: Sync, A: ConfigReader](
+      source: ConfigSource): F[Either[NonEmptyList[String], A]] = {
     Sync[F].delay(source.load[A].leftMap(convertFailures))
   }
 
   /** Loads the case class `A` using Lightbend Config's standard behavior or raises an exception. */
-  def makeOrRaise[F[_]: Sync, A: ConfigReader: ClassTag]: F[A] = makeOrRaise(ConfigSource.default)
+  def makeOrRaise[F[_]: Sync, A: ConfigReader: ClassTag]: F[A] =
+    makeOrRaise(ConfigSource.default)
 
   /** Loads the case class `A` using provided [[pureconfig.ConfigSource]] or raises an exception. */
-  def makeOrRaise[F[_]: Sync, A: ConfigReader: ClassTag](source: ConfigSource): F[A] = Sync[F].delay(source.loadOrThrow[A])
+  def makeOrRaise[F[_]: Sync, A: ConfigReader: ClassTag](
+      source: ConfigSource): F[A] = Sync[F].delay(source.loadOrThrow[A])
 
-  private def convertFailures(failures: ConfigReaderFailures): NonEmptyList[String] = {
+  /**
+    * Loads the case class `A` using Lightbend Config's standard behavior with possible override from files selected via environment variables (`configNames`)`.`
+    */
+  def makeWithMultipleFiles[F[_]: Sync, A: ConfigReader](
+      configNames: List[String],
+      env: Map[String, String] = sys.env,
+      namingConventions: Set[NamingConvention] = Set(KebabCase, CamelCase),
+      config: Config = ConfigFactory.load()
+  ): F[Either[NonEmptyList[String], A]] = {
+    makeWithFallbacks(configNames, None, env, namingConventions, config)
+  }
+
+  /**
+    * Loads the case class `A` using Lightbend Config's standard behavior with possible override from environment variables with `prefix`.
+    * Namespaces are separated by two underscores __ and name parts using single underscore.
+    * Example: "MY_PREFIX__HTTP_CLIENT__TIMEOUT" is equal to "httpClient.timeout" when camelCase formatting is used.
+    */
+  def makeWithEnvironmentVariables[F[_]: Sync, A: ConfigReader](
+      prefix: String,
+      env: Map[String, String] = sys.env,
+      namingConventions: Set[NamingConvention] = Set(KebabCase, CamelCase),
+      config: Config = ConfigFactory.load()
+  ): F[Either[NonEmptyList[String], A]] = {
+    makeWithFallbacks(List.empty, Some(prefix), env, namingConventions, config)
+  }
+
+  def makeWithFallbacks[F[_]: Sync, A: ConfigReader](
+      configNames: List[String],
+      prefix: Option[String],
+      env: Map[String, String] = sys.env,
+      namingConventions: Set[NamingConvention] = Set(KebabCase, CamelCase),
+      config: Config = ConfigFactory.load()
+  ): F[Either[NonEmptyList[String], A]] = {
+    for {
+      finalConfig <- Sync[F].delay(
+        loadAndCombineConfigs(configNames,
+                              prefix,
+                              env,
+                              namingConventions,
+                              config))
+      result <- make[F, A](ConfigSource.fromConfig(finalConfig))
+    } yield result
+  }
+
+  private def convertFailures(
+      failures: ConfigReaderFailures): NonEmptyList[String] = {
     NonEmptyList(failures.head, failures.tail.toList).map(formatFailure)
   }
 
-  private def formatFailure(configReaderFailure: ConfigReaderFailure): String = {
+  private def formatFailure(
+      configReaderFailure: ConfigReaderFailure): String = {
     configReaderFailure match {
       case convertFailure: ConvertFailure =>
         s"Invalid configuration ${convertFailure.path}: ${convertFailure.description}"
@@ -38,4 +102,68 @@ object PureConfigModule {
     }
   }
 
+  private def loadAndCombineConfigs(
+      configNames: List[String],
+      prefix: Option[String],
+      env: Map[String, String],
+      namingConventions: Set[NamingConvention],
+      config: Config
+  ): Config = {
+    val defaultConfig = ConfigFactory.load(config)
+    val additionalConfigs = loadAdditionalConfigs(configNames, env)
+    val environmentConfig =
+      loadEnvironmentConfig(prefix, env, namingConventions)
+
+    environmentConfig.withFallback(
+      additionalConfigs.withFallback(defaultConfig))
+  }
+
+  private def loadAdditionalConfigs(configNames: List[String],
+                                    env: Map[String, String]): Config = {
+    configNames.foldLeft(ConfigFactory.empty()) { (config, key) =>
+      env
+        .get(key)
+        .map(value => ConfigFactory.parseResources(s"$value.conf"))
+        .fold(config)(config.withFallback(_))
+    }
+  }
+
+  private def loadEnvironmentConfig(
+      prefix: Option[String],
+      env: Map[String, String],
+      namingConventions: Set[NamingConvention]): Config = {
+    prefix match {
+      case Some(value) =>
+        namingConventions.foldLeft(ConfigFactory.empty()) {
+          (cfg, namingConvention) =>
+            cfg.withFallback(environmentConfig(value, env, namingConvention))
+        }
+      case None => ConfigFactory.empty()
+    }
+
+  }
+
+  /** Parses map where keys are configuration options, and values are config values. Namespaces are separated by two underscores __ and name
+    * parts using single underscore. Example: MY_PREFIX__HTTP_CLIENT__TIMEOUT is equal to httpClient.timeout when camelCase formatting is
+    * used.
+    */
+  def environmentConfig(prefix: String,
+                        environment: Map[String, String],
+                        namingConvention: NamingConvention): Config = {
+    val parsedPrefix =
+      namingConvention.toTokens(prefix).mkString("_").toUpperCase
+    val filteredEnvironment =
+      environment.view.filter(_._1.startsWith(parsedPrefix))
+
+    val properties = new Properties()
+    filteredEnvironment.foreach {
+      case (name, value) =>
+        val namespaces = name.stripPrefix(s"${prefix}__").split("__")
+        val namespacesCase = namespaces
+          .map(_.toLowerCase.split('_').toList)
+          .map(namingConvention.fromTokens)
+        properties.setProperty(namespacesCase.mkString("."), value)
+    }
+    ConfigFactory.parseProperties(properties)
+  }
 }

--- a/pureconfig/src/test/resources/special_config.conf
+++ b/pureconfig/src/test/resources/special_config.conf
@@ -1,0 +1,4 @@
+test-object {
+  some-key = "value3"
+}
+

--- a/pureconfig/src/test/scala/com/avast/sst/pureconfig/PureConfigModuleTest.scala
+++ b/pureconfig/src/test/scala/com/avast/sst/pureconfig/PureConfigModuleTest.scala
@@ -2,6 +2,7 @@ package com.avast.sst.pureconfig
 
 import cats.data.NonEmptyList
 import cats.effect.SyncIO
+import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 import pureconfig.error.ConfigReaderException
 import pureconfig.generic.semiauto.deriveReader
@@ -9,27 +10,77 @@ import pureconfig.{ConfigReader, ConfigSource}
 
 class PureConfigModuleTest extends AnyFunSuite {
 
-  private val source = ConfigSource.string("""|number = 123
-                                              |string = "test"""".stripMargin)
+  private val config = ConfigFactory.parseString("""|number = 123
+                                                    |string = "test"
+                                                    |test-object {
+                                                    |   some-key = "value1"
+                                                    |} """.stripMargin)
 
-  private case class TestConfig(number: Int, string: String)
+  private case class TestConfig(number: Int, string: String, testObject: TestObject)
+  private case class TestObject(someKey: String)
 
-  implicit private val configReader: ConfigReader[TestConfig] = deriveReader
+  implicit private val testConfigReader: ConfigReader[TestConfig] = deriveReader
+  implicit private val objectConfigReader: ConfigReader[TestObject] =
+    deriveReader
+
+  private val source = ConfigSource.fromConfig(config)
 
   test("Simple configuration loading") {
-    assert(PureConfigModule.make[SyncIO, TestConfig](source).unsafeRunSync() === Right(TestConfig(123, "test")))
     assert(
-      PureConfigModule.make[SyncIO, TestConfig](ConfigSource.empty).unsafeRunSync() === Left(
-        NonEmptyList("Invalid configuration : Key not found: 'number'.", List("Invalid configuration : Key not found: 'string'."))
+      PureConfigModule
+        .make[SyncIO, TestConfig](source)
+        .unsafeRunSync() === Right(TestConfig(123, "test", TestObject("value1")))
+    )
+    assert(
+      PureConfigModule
+        .make[SyncIO, TestConfig](ConfigSource.empty)
+        .unsafeRunSync() === Left(
+        NonEmptyList(
+          "Invalid configuration : Key not found: 'number'.",
+          List("Invalid configuration : Key not found: 'string'.", "Invalid configuration : Key not found: 'test-object'.")
+        )
       )
     )
   }
 
   test("Configuration loading with exceptions") {
-    assert(PureConfigModule.makeOrRaise[SyncIO, TestConfig](source).unsafeRunSync() === TestConfig(123, "test"))
+    assert(
+      PureConfigModule
+        .makeOrRaise[SyncIO, TestConfig](source)
+        .unsafeRunSync() === TestConfig(123, "test", TestObject("value1"))
+    )
     assertThrows[ConfigReaderException[TestConfig]] {
-      PureConfigModule.makeOrRaise[SyncIO, TestConfig](ConfigSource.empty).unsafeRunSync()
+      PureConfigModule
+        .makeOrRaise[SyncIO, TestConfig](ConfigSource.empty)
+        .unsafeRunSync()
     }
   }
 
+  test("Configuration loading with environment variable override") {
+    val env = Map("PREFIX__TEST_OBJECT__SOME_KEY" -> "value2")
+    val conf = PureConfigModule
+      .makeWithEnvironmentVariables[SyncIO, TestConfig]("PREFIX", env = env, config = config)
+      .unsafeRunSync()
+
+    assert(conf === Right(TestConfig(123, "test", TestObject("value2"))))
+  }
+
+  test("Configuration loading with config file override") {
+    val env = Map("SERVER_FLAG" -> "special_config")
+    val conf = PureConfigModule
+      .makeWithMultipleFiles[SyncIO, TestConfig](List("SERVER_FLAG"), env = env, config = config)
+      .unsafeRunSync()
+
+    assert(conf === Right(TestConfig(123, "test", TestObject("value3"))))
+  }
+
+  test("Configuration loading with config file override and environment variable override") {
+    val env =
+      Map("SERVER_FLAG" -> "special_config", "PREFIX__STRING" -> "test2")
+    val conf = PureConfigModule
+      .makeWithFallbacks[SyncIO, TestConfig](List("SERVER_FLAG"), Some("PREFIX"), env = env, config = config)
+      .unsafeRunSync()
+
+    assert(conf === Right(TestConfig(123, "test2", TestObject("value3"))))
+  }
 }


### PR DESCRIPTION
This PR wants to provide the possibility to override configuration based on server specifics. For example when you have service distributed in different locations where some of them have a slower connection and you need to change timeouts for them or if you need to override some flags 